### PR TITLE
Update PULL_REQUEST_TEMPLATE.md, A vs. An

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Make sure these boxes checked before submitting your pull request.
 - [] Write good commit message, try to squash your commits into a single one
 - [] Run `./build.sh` in `gh-pages` branch for document changes
 
-For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.
+For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.
 
 Thank you.
 


### PR DESCRIPTION
Only a small change.

`a` agreement => `an` agreement

Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [x] New code/logic commented & tested
- [x] Write good commit message, try to squash your commits into a single one
- [x] Run `./build.sh` in `gh-pages` branch for document changes

For significant changes like big bug fixes, new features, please open an issue to make a agreement on an implementation design/plan first before starting it.

Thank you.


### What did this pull request do?
Change the pull request template to use `an` instead of `a` when the article `AN` is used before singular, countable nouns which begin with vowel sounds.